### PR TITLE
Convert repo list to square card grid layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
         "typescript": "~3.7.2"
     },
     "scripts": {
-        "start": "react-scripts start",
-        "start:dev": "TSC_COMPILE_ON_ERROR=true react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
+        "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+        "start:dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider TSC_COMPILE_ON_ERROR=true react-scripts start",
+        "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+        "test": "cross-env NODE_OPTIONS=--openssl-legacy-provider react-scripts test",
         "eject": "react-scripts eject",
         "lint": "eslint 'src/**'",
         "lint:fix": "eslint 'src/**' --fix",
@@ -70,12 +70,13 @@
         "eslint-plugin-react": "^7.20.0",
         "eslint-plugin-react-hooks": "^2.5.1",
         "gh-pages": "^3.0.0",
-        "husky": "^4.2.5"
+        "husky": "^4.2.5",
+        "cross-env": "^7.0.3"
     },
     "husky": {
         "hooks": {
             "pre-commit": "yarn lint",
-            "pre-push": "CI=true react-scripts test && yarn deploy"
+            "pre-push": "cross-env NODE_OPTIONS=--openssl-legacy-provider CI=true react-scripts test && yarn deploy"
         }
     },
     "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/src/components/RepoCard/index.css
+++ b/src/components/RepoCard/index.css
@@ -6,13 +6,17 @@
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
+    width: 100%;
+    height: 100%;
 }
 
 .repo-card__inner {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    flex-direction: column;
     gap: 1rem;
+    align-items: flex-start;
+    flex: 1;
+    overflow: auto;
 }
 
 .repo-card__left {
@@ -34,7 +38,9 @@
     align-items: center;
     font-size: 1.4rem;
     color: var(--gray-9);
-    white-space: nowrap;
+    white-space: normal;
+    flex-wrap: wrap;
+    row-gap: 0.6rem;
 }
 
 .repo-card__name {
@@ -90,14 +96,18 @@
 .repo-card__footer {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    margin-top: 0.6rem;
+    align-items: flex-end;
+    margin-top: auto;
+    padding-top: 0.6rem;
+    flex-wrap: wrap;
+    gap: 0.6rem;
 }
 
 .repo-card__badges {
     display: flex;
     gap: 0.6rem;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .repo-card__badge {
@@ -153,6 +163,11 @@
     background: var(--white-base);
     box-shadow: 0 8px 20px rgba(2,6,23,.06);
     transition: transform .15s ease, box-shadow .18s ease;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 
 .repo-card__card:hover { transform: translateY(-4px); box-shadow: 0 18px 40px rgba(2,6,23,.10); }

--- a/src/components/Scroller/index.tsx
+++ b/src/components/Scroller/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // Scroller intentionally disabled — removed scroll-to-top control per UX request.
 const Scroller = () => null;
 

--- a/src/features/reposList/RepoList.css
+++ b/src/features/reposList/RepoList.css
@@ -14,10 +14,11 @@
     display: flex;
     align-items: stretch;
     justify-content: center;
-    padding: 0;
+    padding: 1rem;
     border-top: none;
     aspect-ratio: 1 / 1;
     min-height: 24rem;
+    overflow: hidden;
 }
 
 .repo-list--item:hover .repo-card__card {

--- a/src/features/reposList/RepoList.css
+++ b/src/features/reposList/RepoList.css
@@ -2,8 +2,8 @@
     list-style: none;
     padding: 1rem;
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr));
+    gap: 1.4rem;
 }
 
 .repos-list__container {
@@ -11,15 +11,16 @@
 }
 
 .repo-list--item {
-    padding: 1rem;
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    padding: 0;
     border-top: none;
-    background: var(--white-base);
-    border-radius: 12px;
-    box-shadow: 0 8px 20px rgba(2,6,23,.06);
-    transition: transform .15s ease, box-shadow .18s ease, background-color .18s ease;
+    aspect-ratio: 1 / 1;
+    min-height: 24rem;
 }
 
-.repo-list--item:hover {
+.repo-list--item:hover .repo-card__card {
     transform: translateY(-6px);
     box-shadow: 0 14px 40px rgba(2,6,23,.12);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3433,6 +3433,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -3452,6 +3459,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.11.0:
   version "3.12.0"


### PR DESCRIPTION
## Purpose
Convert the repository list from a single-column layout to a responsive grid of square cards to improve visual presentation and better utilize screen space.

## Code changes
- **Grid layout**: Updated CSS to use `grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr))` for responsive card grid
- **Square cards**: Added `aspect-ratio: 1 / 1` and `min-height: 24rem` to create uniform square cards
- **Card structure**: Modified RepoCard component to use flexbox column layout with proper overflow handling
- **Responsive design**: Enhanced card content layout with flexible wrapping and improved spacing
- **Build compatibility**: Added cross-env dependency and NODE_OPTIONS flag to resolve OpenSSL legacy provider issues
- **Code cleanup**: Removed unused React import from Scroller component

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3a4e9cf599ae435fa5a6c8a5e9ecbb8f/mystic-realm)

👀 [Preview Link](https://3a4e9cf599ae435fa5a6c8a5e9ecbb8f-mystic-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3a4e9cf599ae435fa5a6c8a5e9ecbb8f</projectId>-->
<!--<branchName>mystic-realm</branchName>-->